### PR TITLE
Write to log handler instead of pickle -> json

### DIFF
--- a/pytest_instrument/logging_helpers.py
+++ b/pytest_instrument/logging_helpers.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+import logging
+
+from pythonjsonlogger import jsonlogger
+
+
+class CustomJsonFormatter(jsonlogger.JsonFormatter):
+    def add_fields(self, log_record, record, message_dict):
+        super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
+        if not log_record.get("timestamp"):
+            log_record["timestamp"] = datetime.fromtimestamp(record.created).strftime(
+                "%Y-%m-%d %H:%M:%S.%f"
+            )
+        if log_record.get("level"):
+            log_record["level"] = log_record["level"].lower()
+        else:
+            log_record["level"] = record.levelname.lower()
+
+
+def logfile_handler(logfile):
+    formatter = CustomJsonFormatter("(timestamp) (level) (name) (message)")
+    log_handler = logging.FileHandler(logfile)
+    log_handler.setFormatter(formatter)
+    return log_handler

--- a/pytest_instrument/logging_helpers.py
+++ b/pytest_instrument/logging_helpers.py
@@ -18,7 +18,7 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
 
 
 def logfile_handler(logfile):
-    formatter = CustomJsonFormatter("(timestamp) (level) (name) (message)")
+    formatter = CustomJsonFormatter("%(timestamp) %(level) %(name) %(message)")
     log_handler = logging.FileHandler(logfile)
     log_handler.setFormatter(formatter)
     return log_handler

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=read("README.rst"),
     packages=["pytest_instrument"],
     python_requires=">=3.6",
-    install_requires=["pytest>=5.1.0"],
+    install_requires=["pytest>=5.1.0", "python-json-logger>=0.1.11"],
     tests_require=["jsonschema>=3.1.1"],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,27 +8,29 @@ UUID4_REGEX = "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89abAB][a-fA-F0-9
 START_STOP_REGEX = "^[0-9]{10}\\.[0-9]{1,7}$"
 DURATION_REGEX = "^[0-9]{1,}\\.[0-9]{1,12}$"
 
-JSON_SCHEMA = {
-    "type": "array",
-    "items": {
-        "type": "object",
-        "properties": {
-            "session_id": {"type": "string", "pattern": UUID4_REGEX},
-            "record_id": {"type": "string", "pattern": UUID4_REGEX},
-            "node_id": {"type": "string"},
-            "when": {"type": "string", "enum": ["setup", "call", "teardown"]},
-            "outcome": {"type": "string", "enum": ["passed", "failed", "skipped"]},
-            "start": {"type": "string", "pattern": START_STOP_REGEX},
-            "stop": {"type": "string", "pattern": START_STOP_REGEX},
-            "duration": {"type": "string", "pattern": DURATION_REGEX},
-            "labels": {"type": ["array", "null"]},
-            "tags": {"type": ["object", "null"]},
-            "fixtures": {"type": ["array", "null"]},
-        },
-        "additionalProperties": False,
-        "minProperties": 11,
-        "uniqueItems": True,
+
+LOG_RECORD_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "timestamp": {"type": "string"},
+        "level": {"type": "string"},
+        "name": {"type": ["string", "null"]},
+        "message": {"type": "string"},
+        "session_id": {"type": "string", "pattern": UUID4_REGEX},
+        "record_id": {"type": "string", "pattern": UUID4_REGEX},
+        "node_id": {"type": "string"},
+        "when": {"type": "string", "enum": ["setup", "call", "teardown"]},
+        "outcome": {"type": "string", "enum": ["passed", "failed", "skipped"]},
+        "start": {"type": "string", "pattern": START_STOP_REGEX},
+        "stop": {"type": "string", "pattern": START_STOP_REGEX},
+        "duration": {"type": "string", "pattern": DURATION_REGEX},
+        "labels": {"type": ["array", "null"]},
+        "tags": {"type": ["object", "null"]},
+        "fixtures": {"type": ["array", "null"]},
     },
+    "additionalProperties": False,
+    "minProperties": 11,
+    "uniqueItems": True,
 }
 
 
@@ -41,21 +43,23 @@ def get_files_from_artifacts_dir_by_extension(testdir, extension):
     return files
 
 
-def get_records_from_json_file_in_artifacts_dir(testdir, filename):
+def get_records_from_log_file_in_artifacts_dir(testdir, filename):
     artifacts_dir = testdir.tmpdir.join(ARTIFACTS_DIRNAME)
 
-    with open(artifacts_dir.join(filename)) as json_file:
-        json_data = json.load(json_file)
+    with open(artifacts_dir.join(filename)) as log_file:
+        all_records = log_file.readlines()
+        parsed_records = [json.loads(record) for record in all_records]
 
-    return json_data
-
-
-def get_json_file_from_artifacts_dir_and_return_records(testdir):
-    json_files = get_files_from_artifacts_dir_by_extension(testdir, "json")
-    assert len(json_files) == 1
-
-    return get_records_from_json_file_in_artifacts_dir(testdir, json_files[0])
+    return parsed_records
 
 
-def validate_json(json__records):
-    validate(instance=json__records, schema=JSON_SCHEMA)
+def get_log_file_from_artifacts_dir_and_return_records(testdir):
+    log_files = get_files_from_artifacts_dir_by_extension(testdir, "log")
+    assert len(log_files) == 1
+
+    return get_records_from_log_file_in_artifacts_dir(testdir, log_files[0])
+
+
+def json_validate_each_record(records):
+    for record in records:
+        validate(instance=record, schema=LOG_RECORD_SCHEMA)

--- a/tests/test_file_handling.py
+++ b/tests/test_file_handling.py
@@ -10,32 +10,21 @@ def tests_filename(testdir):
     return filename
 
 
-def test_single_json_file_is_created(testdir, tests_filename):
+def test_single_log_file_is_created(testdir, tests_filename):
     test_to_run = "test_passes"
     result = testdir.runpytest(
         "-vs", "--instrument", f"{tests_filename}::{test_to_run}"
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    json_files = helpers.get_files_from_artifacts_dir_by_extension(testdir, "json")
-    assert len(json_files) == 1
+    log_files = helpers.get_files_from_artifacts_dir_by_extension(testdir, "log")
+    assert len(log_files) == 1
 
 
-def test_pickle_file_is_removed(testdir, tests_filename):
-    test_to_run = "test_passes"
-    result = testdir.runpytest(
-        "-vs", "--instrument", f"{tests_filename}::{test_to_run}"
-    )
-    result.assert_outcomes(error=0, failed=0, passed=1)
-
-    pickle_files = helpers.get_files_from_artifacts_dir_by_extension(testdir, "pickle")
-    assert len(pickle_files) == 0
-
-
-def test_without_instrument_option(testdir, tests_filename):
+def test_no_file_created_without_instrument_option(testdir, tests_filename):
     test_to_run = "test_passes"
     result = testdir.runpytest("-vs", f"{tests_filename}::{test_to_run}")
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    json_files = helpers.get_files_from_artifacts_dir_by_extension(testdir, "json")
-    assert len(json_files) == 0
+    log_files = helpers.get_files_from_artifacts_dir_by_extension(testdir, "log")
+    assert len(log_files) == 0

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -18,8 +18,8 @@ def test_setup_fixtures_with_different_scopes(testdir, tests_filename, fixture_s
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_fixtures = [f"setup_fixture_with_{fixture_scope}_scope"]
     assert len(
@@ -37,8 +37,8 @@ def test_teardown_fixtures_with_different_scopes(
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_fixtures = [f"teardown_fixture_with_{fixture_scope}_scope"]
     assert len(
@@ -53,8 +53,8 @@ def test_multiple_fixtures(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_fixtures = [
         "setup_fixture_with_function_scope",
@@ -72,8 +72,8 @@ def test_without_fixtures(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     assert len([record for record in records if record["fixtures"] is None]) == len(
         records
@@ -87,8 +87,8 @@ def test_named_fixture(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_fixtures = ["named_fixture"]
     assert len(
@@ -103,8 +103,8 @@ def test_child_fixture(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_fixtures = ["child_fixture", "parent_fixture"]
     assert len(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -13,7 +13,9 @@ def test_label_hook_sets_first_label(testdir):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
+
     expected_labels = [label]
     assert len(
         [record for record in records if record["labels"] == expected_labels]
@@ -32,7 +34,9 @@ def test_label_hook_adds_label(testdir):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
+
     expected_labels = ["a_mark", label]
     assert len(
         [record for record in records if record["labels"] == expected_labels]
@@ -55,7 +59,9 @@ def test_tag_hook_sets_first_tag(testdir):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
+
     expected_tags = {tag_key: tag_value}
     assert len(
         [record for record in records if record["tags"] == expected_tags]
@@ -78,8 +84,8 @@ def test_tag_hook_adds_tag(testdir):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_tags = {"my_mark": "a_mark", tag_key: tag_value}
     assert len(
@@ -98,8 +104,8 @@ def test_fixture_hook_removes_fixture(testdir):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     assert len([record for record in records if record["fixtures"] is None]) == len(
         records

--- a/tests/test_labels_and_tags.py
+++ b/tests/test_labels_and_tags.py
@@ -16,8 +16,8 @@ def test_single_arg_in_mark_instrument(testdir, tests_filename):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_labels = ["a_mark"]
     assert len(
@@ -31,8 +31,8 @@ def test_single_kwarg_in_mark_instrument(testdir, tests_filename):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_tags = {"my_mark": "a_mark"}
     assert len(
@@ -46,8 +46,8 @@ def test_multiple_args_in_mark_instrument(testdir, tests_filename):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_labels = ["a_mark", "another_mark"]
     assert len(
@@ -61,8 +61,8 @@ def test_multiple_kwargs_in_mark_instrument(testdir, tests_filename):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_tags = {"my_mark": "a_mark", "my_other_mark": "another_mark"}
     assert len(
@@ -76,8 +76,8 @@ def test_with_single_arg_and_single_kwarg_in_mark_instrument(testdir, tests_file
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_labels = ["a_mark"]
     assert len(
@@ -96,8 +96,8 @@ def test_without_args_or_kwars_in_mark_instrument(testdir, tests_filename):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_labels = None
     assert len(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -18,8 +18,8 @@ def test_record_id(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     for record in records:
         try:
@@ -37,8 +37,8 @@ def test_session_id(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=2)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     for record in records:
         try:

--- a/tests/test_node_id.py
+++ b/tests/test_node_id.py
@@ -17,8 +17,8 @@ def test_file_test(testdir, tests_filename):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_node_id = f"{tests_filename}::{test_to_run}"
     assert len(
@@ -34,8 +34,8 @@ def test_file_class_test(testdir, tests_filename):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_node_id = f"{tests_filename}::{class_to_run}::{test_to_run}"
     assert len(
@@ -53,8 +53,8 @@ def test_folder_file_test(testdir):
     )
     result.assert_outcomes(passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_node_id = f"{tests_folder}/{tests_filename}::{test_to_run}"
     assert len(

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -17,8 +17,8 @@ def test_result_call_passes(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_when = "call"
     expected_outcome = "passed"
@@ -42,8 +42,8 @@ def test_result_call_fails(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=1, passed=0)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_when = "call"
     expected_outcome = "failed"
@@ -67,8 +67,8 @@ def test_result_setup_passes(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_when = "setup"
     expected_outcome = "passed"
@@ -92,8 +92,8 @@ def test_result_setup_fails(testdir, tests_filename):
     )
     result.assert_outcomes(error=1, failed=0, passed=0)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_when = "setup"
     expected_outcome = "failed"
@@ -117,8 +117,8 @@ def test_result_teardown_passes(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_when = "teardown"
     expected_outcome = "passed"
@@ -142,8 +142,8 @@ def test_result_teardown_fails(testdir, tests_filename):
     )
     result.assert_outcomes(error=1, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_when = "teardown"
     expected_outcome = "failed"
@@ -167,8 +167,8 @@ def test_result_setup_and_teardown_fail(testdir, tests_filename):
     )
     result.assert_outcomes(error=1, failed=0, passed=0)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_when = "setup"
     expected_outcome = "failed"
@@ -209,8 +209,8 @@ def test_result_skipped(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=0, skipped=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     expected_when = "setup"
     expected_outcome = "skipped"

--- a/tests/test_start_stop_duration.py
+++ b/tests/test_start_stop_duration.py
@@ -17,8 +17,8 @@ def test_record_start(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
     for record in records:
         assert float(record["start"]).is_integer() is False
@@ -31,10 +31,9 @@ def test_record_stop(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
-    helpers.validate_json(records)
     for record in records:
         assert float(record["stop"]).is_integer() is False
 
@@ -46,9 +45,8 @@ def test_record_duration(testdir, tests_filename):
     )
     result.assert_outcomes(error=0, failed=0, passed=1)
 
-    records = helpers.get_json_file_from_artifacts_dir_and_return_records(testdir)
-    helpers.validate_json(records)
+    records = helpers.get_log_file_from_artifacts_dir_and_return_records(testdir)
+    helpers.json_validate_each_record(records)
 
-    helpers.validate_json(records)
     for record in records:
         assert float(record["duration"]).is_integer() is False

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ exclude = venv,.tox
 [testenv]
 deps =
     pytest>=5.1.0
+    python-json-logger>=0.1.11
     jsonschema>=3.1.1
 commands = pytest -v -ra {posargs:tests}
 


### PR DESCRIPTION
Old approach: write records to pickle file, after test run convert to json
New approach: write records to logging file handler with json formatter

Reasons:
- cleaner to write just one file
- reading a file of JSON objects (instead of JSON array) is easy enough
- anticipates merging improved pytest-logfest functionality into this plugin